### PR TITLE
fixed bug related to vertical images and rectangle area type

### DIFF
--- a/source/js/classes/crop-area.js
+++ b/source/js/classes/crop-area.js
@@ -140,7 +140,7 @@ crop.factory('cropArea', ['cropCanvas', function(CropCanvas) {
                 if(this._minSize.h>newSizeHeight) newSizeHeight=this._minSize.h;
                 nw.x=canvasW-newSizeWidth;
             }
-            if(nw.y+newSizeHeight>canvasW) nw.y=canvasW-newSizeHeight;
+            if(nw.y+newSizeHeight>canvasH) nw.y=canvasH-newSizeHeight;
         }
 
         // save square scale


### PR DESCRIPTION
@CrackerakiUA I found that when cropping vertical images using rectangle area type the cropping tool would cut off the bottom of the image. This appears to be the bug, but would you confirm this looks correct prior to merging? Seems to have fixed it for me.
