### PR TITLE
Add .npmignore file.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,49 @@
+# Windows image file caches
+Thumbs.db
+ehthumbs.db
+
+# Folder config file
+Desktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msm
+*.msp
+
+# =========================
+# Operating System Files
+# =========================
+
+# OSX
+# =========================
+
+.DS_Store
+.AppleDouble
+.LSOverride
+.tmp
+
+# Icon must ends with two \r.
+Icon
+
+# IDE
+.idea
+
+# Thumbnails
+._*
+
+# Files that might appear on external disk
+.Spotlight-V100
+.Trashes
+
+
+# SASS Cache
+.sass_cache/
+.sass-cache/
+
+# Installed Bower/Node modules
+bower_components/
+node_modules/


### PR DESCRIPTION
By default, npm use .gitignore file if .npmignore is not present. As you ignored `compile` dir, npm package miss compiled files, which makes it impossible to use without building manually. I just cp'ed your .gitignore file to .npmignore and removed `compile` dir from it.
