### PR TITLE
type checking for new image source added before `newImage.crossOrigin` set

### DIFF
--- a/source/js/classes/crop-host.js
+++ b/source/js/classes/crop-host.js
@@ -355,7 +355,7 @@ crop.factory('cropHost', ['$document', '$q', 'cropAreaCircle', 'cropAreaSquare',
             events.trigger('image-updated');
             if (!!imageSource) {
                 var newImage = new Image();
-                if (imageSource.substring(0,4).toLowerCase()==='http') {
+                if (typeof imageSource == 'string' &&  imageSource.substring(0,4).toLowerCase()==='http') { // `imageSource` can be of type `Blob`
                     newImage.crossOrigin = 'anonymous';
                 }
                 newImage.onload = function() {


### PR DESCRIPTION
related to this https://github.com/CrackerakiUA/ngImgCropFullExtended/issues/69 issue
