### PR TITLE
Bugfix in setMaxDimensions that caused selections to scale wrong

### DIFF
--- a/compile/unminified/ng-img-crop.js
+++ b/compile/unminified/ng-img-crop.js
@@ -5,7 +5,7 @@
  * Copyright (c) 2016 undefined
  * License: MIT
  *
- * Generated at Friday, April 29th, 2016, 10:47:19 AM
+ * Generated at Friday, May 6th, 2016, 9:45:26 AM
  */
 (function() {
 var crop = angular.module('ngImgCrop', []);
@@ -2591,11 +2591,11 @@ crop.factory('cropHost', ['$document', '$q', 'cropAreaCircle', 'cropAreaSquare',
                     ratioMin = Math.min(ratioNewCurWidth, ratioNewCurHeight);
 
                 //TODO: use top left corner point
+                var center = theArea.getCenterPoint();
                 theArea.setSize({
                     w: theArea.getSize().w * ratioMin,
                     h: theArea.getSize().h * ratioMin
                 });
-                var center = theArea.getCenterPoint();
                 theArea.setCenterPoint({
                     x: center.x * ratioNewCurWidth,
                     y: center.y * ratioNewCurHeight

--- a/source/js/classes/crop-host.js
+++ b/source/js/classes/crop-host.js
@@ -498,11 +498,11 @@ crop.factory('cropHost', ['$document', '$q', 'cropAreaCircle', 'cropAreaSquare',
                     ratioMin = Math.min(ratioNewCurWidth, ratioNewCurHeight);
 
                 //TODO: use top left corner point
+                var center = theArea.getCenterPoint();
                 theArea.setSize({
                     w: theArea.getSize().w * ratioMin,
                     h: theArea.getSize().h * ratioMin
                 });
-                var center = theArea.getCenterPoint();
                 theArea.setCenterPoint({
                     x: center.x * ratioNewCurWidth,
                     y: center.y * ratioNewCurHeight


### PR DESCRIPTION
If the croparea change in size, setMaxDimensions is called and set the new centerpoint for the selection.

However, It first set the new size THEN calculated the old centerpoint using the value of the new size instead of the old
Now we set size AFTER the old centerpoint is calculated

Codepen where bug is exposed (crop area resizes after 2 seconds and selection changes): http://codepen.io/anon/pen/reoRQE
