### PR TITLE
Fixed the loading overlay when uploading a bad file

### DIFF
--- a/source/js/ng-img-crop.js
+++ b/source/js/ng-img-crop.js
@@ -151,7 +151,7 @@ crop.directive('imgCrop', ['$timeout', 'cropHost', 'cropPubSub', function ($time
                     scope.onLoadBegin({});
                 }))
                 .on('load-done', fnSafeApply(function (scope) {
-                    angular.element(element.children()[element.children().length - 1]).remove();
+                    element.children(".loading").remove();
                     scope.onLoadDone({});
                 }))
                 .on('load-error', fnSafeApply(function (scope) {


### PR DESCRIPTION
When you select a bad file (xlsx, dll or anything that is not an image) the loading overlay shows. When you after this select a valid image, the image is shown with the loading overlay.

This is because there are now two loading overlays (the first one is not removed).
The pull request removes all loading children messages within the element thus fixing the problem stated above.

To reproduce:
1) Go to http://codepen.io/Crackeraki/pen/avYNKP
2) Select anything other than an image
3) Select a proper image
4) The loading overlay is still visible

Test again with this fix :-).
