### PR TITLE
Removed jQuery dependency

### DIFF
--- a/source/js/ng-img-crop.js
+++ b/source/js/ng-img-crop.js
@@ -151,7 +151,11 @@ crop.directive('imgCrop', ['$timeout', 'cropHost', 'cropPubSub', function ($time
                     scope.onLoadBegin({});
                 }))
                 .on('load-done', fnSafeApply(function (scope) {
-                    element.children(".loading").remove();
+                    var children = element.children();
+                    angular.forEach(children, function (child, index) {
+                        if (angular.element(child).hasClass("loading"))
+                            angular.element(child).remove();
+                    });
                     scope.onLoadDone({});
                 }))
                 .on('load-error', fnSafeApply(function (scope) {


### PR DESCRIPTION
Original pull request: https://github.com/CrackerakiUA/ngImgCropFullExtended/pull/111
This change removes the jQuery dependency.

hasClass is available in jQuery lite (https://gist.github.com/esfand/9638882)
