### PR TITLE
Add angular as a dependency in bower.json instead of a dev depenency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -43,7 +43,7 @@
         "bower_components",
         "test"
     ],
-    "devDependencies": {
+    "dependencies": {
         "angular": "1.4.0"
     }
 }


### PR DESCRIPTION
Otherwise ngImgCropFullExtended could be loaded before angular if wiredep is used to inject the script tags in the html file, and one gets the following error in console: `ng-img-crop.js:1 Uncaught ReferenceError: angular is not defined`
