### PR TITLE
Remove deprecated `version` from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,6 @@
 {
 	"name": "ng-img-crop-full-extended",
 	"prettyName": "ngImgCropFullExtended",
-	"version": "0.6.1",
 	"authors": [{
 		"name": "Alex Kaul",
 		"email": "alexkaul@googlemail.com"


### PR DESCRIPTION
Github tags are used instead.

https://github.com/bower/spec/blob/master/json.md#version
