### PR TITLE
Prevent Js error on iOS

### DIFF
--- a/source/js/classes/crop-exif.js
+++ b/source/js/classes/crop-exif.js
@@ -365,9 +365,8 @@ crop.service('cropEXIF', [function () {
                 }
                 http = null;
             };
-            http.open('GET', img.src, true);
             http.responseType = 'arraybuffer';
-            http.send(null);
+            http.open('GET', img.src, true);
         } else if (window.FileReader && (img instanceof window.Blob || img instanceof window.File)) {
             fileReader.onload = function (e) {
                 if (debug) {

--- a/source/js/classes/crop-exif.js
+++ b/source/js/classes/crop-exif.js
@@ -367,6 +367,10 @@ crop.service('cropEXIF', [function () {
             };
             http.responseType = 'arraybuffer';
             http.open('GET', img.src, true);
+            try {
+                http.send(null);
+            } catch(e) {
+            }
         } else if (window.FileReader && (img instanceof window.Blob || img instanceof window.File)) {
             fileReader.onload = function (e) {
                 if (debug) {


### PR DESCRIPTION
Fixes [#164](https://github.com/CrackerakiUA/ngImgCropFullExtended/issues/164) to prevent a Js error on iOS about synchronous request
